### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pg-track-settings (2.1.1-3) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + Build-Depends: Drop versioned constraint on postgresql-server-dev-all.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Fri, 21 Oct 2022 12:59:11 -0000
+
 pg-track-settings (2.1.1-2) unstable; urgency=medium
 
   * Team upload for PostgreSQL 15.

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: database
 Priority: optional
 Maintainer: Julien Rouhaud <rjuju123@gmail.com>
 Standards-Version: 4.6.1
-Build-Depends: debhelper-compat (= 13), postgresql-server-dev-all (>= 141~)
+Build-Depends: debhelper-compat (= 13), postgresql-server-dev-all
 Rules-Requires-Root: no
 Homepage: https://powa.readthedocs.io/
 Vcs-Browser: https://github.com/rjuju/pg_track_settings


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/pg-track-settings/cbfe2580-1aa9-4d8f-92d3-a319ba225f0d.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/cbfe2580-1aa9-4d8f-92d3-a319ba225f0d/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/cbfe2580-1aa9-4d8f-92d3-a319ba225f0d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/cbfe2580-1aa9-4d8f-92d3-a319ba225f0d/diffoscope)).
